### PR TITLE
Hotfix request validation

### DIFF
--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -38,10 +38,12 @@
     * ```py
       python runserver -d
       ```
+* After this you are able to report data to a mediawiki instance and to a git repository. Which is described with more details in the [Reporting data section](####reporting-data)
 
 ##### Build with docker
 
 * To have your local environment working using docker it's required that you have [Docker](https://docs.docker.com/get-started/) and [Docker Compose](https://docs.docker.com/compose/) to be installed in your computer. Afterwards you'll just need:
+    * In case this is the first time you are running this setup, it is necessary to create a network for the docker containers with the command: `docker network create oeg-reporter`.
     * One command to get everything together and start the OEG Reporter: `docker-compose up -d backend`
     * After this you are able to report data to a mediawiki instance and to a git repository. Which is described with more details in the [Reporting data section](####reporting-data)
 
@@ -60,7 +62,8 @@
 
 ##### Report to a mediawiki instance
 
-* To add new data to a mediawiki instance, you can send a `POST` request in the endpoint `/wiki/` with a JSON in the following format:
+* To add new data to a mediawiki instance, you can send a `POST` request in the endpoint `/wiki/` using `curl` through your terminal, or any other tool for testing APIs with the json following JSON fields:<br>
+**Important:** Add the `Content-Type: application/json` and `Authorization: Token <secret defined in the .env config file>` headers to your request, without this the request is going to fail.
 
 ```json
 {
@@ -105,7 +108,8 @@
     - Project page - `http://localhost:8080/index.php/Organised_Editing/Activities/Auto_report/Projects/Project_name`
 
 * To update data in the mediawiki instance, you need to send a `PATCH` request in the `/wiki/<organisation_name>/<project_name>` endpoint with the same JSON fields. **Important**: It's not required to send all fields in the JSON because all of them are optional.
-* For example, to update some data from the project `Project name` from the organisation `Organisation name` the `PATCH` request will be `http://localhost:5001/wiki/organisation name/project name/` and the JSON data *must* contain at least one field of the shown in the `POST` request previously. In this example the project will have its license and status updated:
+* For example, to update some data from the project `Project name` from the organisation `Organisation name` the `PATCH` request will be `http://localhost:5001/wiki/organisation name/project name/` and the JSON data *must* contain at least one field of the shown in the `POST` request previously. In this example the project will have its license and status updated:<br>
+**Important:** Add the `Content-Type: application/json` and `Authorization: Token <secret defined in the .env config file>` headers to your request, without this the request is going to fail.
 ```json
 {
     "project":{
@@ -118,8 +122,8 @@
 
 ##### Report to a git repository
 
-* To add new data to a git repository, you can send a `POST` request in the endpoint `/git/` with a JSON in the following format:
-
+* To add new data to a git repository, you can send a `POST` request in the endpoint `/git/` using `curl` through your terminal, or any other tool for testing APIs with the json following JSON fields:<br>
+**Important:** Add the `Content-Type: application/json` and `Authorization: Token <secret defined in the .env config file>` headers to your request, without this the request is going to fail.
 ```json
 {
     "project":{
@@ -160,7 +164,8 @@
 * If everything worked it should create a file in the git repository cloned in your local computer as described in the [git repository setup](/docs/git-repository-setup.md), commit and push it to the remote repository. The project is reported following this predefined folder structure `github_files/<platform_name>/<organisation_name>`, in this case the structure of the reported project data would be `github_files/Platform_example/organisation_name/project_1.yaml`.
 
 * To update data in the mediawiki instance, you need to send a `PATCH` request in the `/git/<platform_name>/<organisation_name>/<project_id>` endpoint with the same JSON fields. **Important**: It's not required to send all fields in the JSON because all of them are optional.
-* For example, to update some data from the project `Project name` from the organisation `Organisation name` the `PATCH` request will be `http://localhost:5001/git/Platform example/organisation name/1/` and the JSON data *must* contain at least one field of the shown in the `POST` request previously. In this example the project will have its license and short description updated:
+* For example, to update some data from the project `Project name` from the organisation `Organisation name` the `PATCH` request will be `http://localhost:5001/git/Platform example/organisation name/1/` and the JSON data *must* contain at least one field of the shown in the `POST` request previously. In this example the project will have its license and short description updated:<br>
+**Important:** Add the `Content-Type: application/json` and `Authorization: Token <secret defined in the .env config file>` headers to your request, without this the request is going to fail.
 ```json
 {
     "project":{

--- a/server/api/git/resources.py
+++ b/server/api/git/resources.py
@@ -26,7 +26,7 @@ class GitDocumentApi(MethodView):
         except FileServiceError as e:
             return {"detail": f"{str(e)}"}, 409
         except ValidationError as e:
-            return {"detail": f"{str(e)}"}, 400
+            return {"detail": f"Error validating report data {str(e)}"}, 400
 
     @check_token
     def patch(self, platform_name: str, organisation_name: str, project_id: int):
@@ -39,4 +39,4 @@ class GitDocumentApi(MethodView):
         except FileServiceError as e:
             return {"detail": f"{str(e)}"}, 409
         except ValidationError as e:
-            return {"detail": f"{str(e)}"}, 400
+            return {"detail": f"Error validating report data {str(e)}"}, 400

--- a/server/api/wiki/resources.py
+++ b/server/api/wiki/resources.py
@@ -3,6 +3,7 @@ from flask import request
 from flask import current_app
 
 from marshmallow.exceptions import ValidationError
+from requests.exceptions import ConnectionError
 
 from server.services.wiki.mediawiki_service import MediaWikiServiceError
 from server.services.wiki.pages.organisation_service import OrganisationPageService
@@ -10,13 +11,17 @@ from server.services.wiki.pages.project_service import ProjectPageService
 from server.services.wiki.pages.overview_service import OverviewPageService
 from server.services.wiki.pages.utils import generate_document_data_from_wiki_pages
 from server.services.utils import check_token
-from requests.exceptions import ConnectionError
+from server.models.serializers.document import DocumentSchema
 
 
 class WikiDocumentApi(MethodView):
     @check_token
     def post(self):
         try:
+            # Validate report data
+            document_schema = DocumentSchema(partial=True)
+            document_schema.load(request.json)
+
             overview_page = OverviewPageService()
             if overview_page.enabled_to_report(request.json):
                 overview_page.create_page(request.json)
@@ -40,7 +45,7 @@ class WikiDocumentApi(MethodView):
         except ConnectionError:
             return {"detail": "Error in connection with Mediawiki"}, 500
         except ValidationError as e:
-            return {"detail": f"{str(e)}"}, 400
+            return {"detail": f"Error validating report data: {str(e)}"}, 400
         except Exception as e:
             error_msg = f"Wiki POST - unhandled error: {str(e)}"
             current_app.logger.error(error_msg)
@@ -49,6 +54,10 @@ class WikiDocumentApi(MethodView):
     @check_token
     def patch(self, organisation_name: str, project_name: str):
         try:
+            # Validate report data
+            document_schema = DocumentSchema(partial=True)
+            document_schema.load(request.json)
+
             updated_document, document = generate_document_data_from_wiki_pages(
                 organisation_name, project_name, request.json
             )
@@ -64,7 +73,7 @@ class WikiDocumentApi(MethodView):
             current_app.logger.error(str(e))
             return {"detail": f"{str(e)}"}, 400
         except ValidationError as e:
-            return {"detail": f"{str(e)}"}, 400
+            return {"detail": f"Error validating report data: {str(e)}"}, 400
         except ConnectionError:
             return {"detail": "Error in connection with Mediawiki"}, 500
         except Exception as e:

--- a/server/services/utils.py
+++ b/server/services/utils.py
@@ -34,8 +34,11 @@ def check_token(f):
     def decorated(*args, **kwargs):
         if "Authorization" in request.headers.keys():
             token_header = request.headers["Authorization"]
-            auth_token = token_header.split(maxsplit=1)[1]
-            if auth_token != current_app.config["AUTHORIZATION_TOKEN"]:
+            try:
+                auth_token = token_header.split(maxsplit=1)[1]
+                if auth_token != current_app.config["AUTHORIZATION_TOKEN"]:
+                    return make_response({"detail": "Invalid authorization token"}, 401)
+            except IndexError:
                 return make_response({"detail": "Invalid authorization token"}, 401)
         else:
             return make_response({"detail": "Authorization token not present"}, 401)


### PR DESCRIPTION
Fix requests validation in the following cases:

- Token sent in the wrong format. The right format is Token <auth token>
- Request sent without the Content-Type: application/json header.

Also, updated the documentation with information about the request headers